### PR TITLE
Improve loading of SDK script

### DIFF
--- a/nexx_integration.module
+++ b/nexx_integration.module
@@ -265,3 +265,20 @@ function nexx_integration_cron() {
     );
   }
 }
+
+/**
+ * Implements hook_library_info_alter().
+ */
+function nexx_integration_library_info_alter(&$libraries, $extension) {
+  // Add dynamic nexxPLAY library script to nexx_integration/base library.
+  if ($extension === 'nexx_integration' && isset($libraries['base'])) {
+    $omnia_id = \Drupal::config('nexx_integration.settings')
+      ->get('omnia_id');
+
+    if ($omnia_id) {
+      $libraries['base']['js']['//arc.nexx.cloud/sdk/' . $omnia_id . '.play'] = [
+        'type' => 'external',
+      ];
+    }
+  }
+}

--- a/src/Plugin/Field/FieldFormatter/NexxVideoPlayer.php
+++ b/src/Plugin/Field/FieldFormatter/NexxVideoPlayer.php
@@ -92,17 +92,6 @@ class NexxVideoPlayer extends FormatterBase implements ContainerFactoryPluginInt
             'library' => [
               'nexx_integration/base',
             ],
-            'html_head' => [
-              [
-                [
-                  '#type' => 'html_tag',
-                  '#tag' => 'script',
-                  '#value' => '',
-                  '#attributes' => ['src' => '//arc.nexx.cloud/sdk/' . $omnia_id . '.play', 'type' => 'text/javascript'],
-                ],
-                'nexx-cloud',
-              ],
-            ],
           ],
           /*
           '#cache' => [


### PR DESCRIPTION
Currently the ```//arc.nexx.cloud/sdk/XXX``` script is loaded only in the player field formatter with a ```html_head``` attachment definition. Unfortunately the script won't be loaded if the formatted video field is e.g. pulled in via Ajax.

With this PR, the SDK script is added dynamically to the library ```nexx_integration/base``` definition, so it gets loaded everywhere where the library is used.